### PR TITLE
Drosophila spelled correctly

### DIFF
--- a/R/studies.R
+++ b/R/studies.R
@@ -160,12 +160,12 @@ print.study_ids <- function(x, ...) {
 ##' @importFrom stats setNames
 ##' @examples
 ##' \dontrun{
-##' res <- studies_find_trees(property="ot:ottTaxonName", value="Drosophilia",
+##' res <- studies_find_trees(property="ot:ottTaxonName", value="Drosophila",
 ##'                           detailed=FALSE)
 ##' ## summary of the trees and associated studies that match this criterion
 ##' res
 ##' ## With metadata about the studies (default)
-##' res <- studies_find_trees(property="ot:ottTaxonName", value="Drosophilia",
+##' res <- studies_find_trees(property="ot:ottTaxonName", value="Drosophila",
 ##'                           detailed=TRUE)
 ##' ## The list of trees for each study that match the search criteria
 ##' list_trees(res)

--- a/man/studies_find_trees.Rd
+++ b/man/studies_find_trees.Rd
@@ -65,12 +65,12 @@ The list of possible values to be used as values for the argument
 }
 \examples{
 \dontrun{
-res <- studies_find_trees(property="ot:ottTaxonName", value="Drosophilia",
+res <- studies_find_trees(property="ot:ottTaxonName", value="Drosophila",
                           detailed=FALSE)
 ## summary of the trees and associated studies that match this criterion
 res
 ## With metadata about the studies (default)
-res <- studies_find_trees(property="ot:ottTaxonName", value="Drosophilia",
+res <- studies_find_trees(property="ot:ottTaxonName", value="Drosophila",
                           detailed=TRUE)
 ## The list of trees for each study that match the search criteria
 list_trees(res)


### PR DESCRIPTION
Noticed this when going through the examples: *Drosophil**ia*** isn't valid but *Drosophil**a*** is.